### PR TITLE
Add simflags

### DIFF
--- a/src/profiling.jl
+++ b/src/profiling.jl
@@ -18,7 +18,7 @@
 #
 
 """
-    simulateWithProfiling(modelName, pathToMo; [pathToOmc], workingDir=pwd(), outputFormat="mat", clean=false])
+    simulateWithProfiling(modelName, moFiles; options)
 
 Simulate Modelica model with profiling enabled using given omc.
 
@@ -132,7 +132,7 @@ end
 
 
 """
-    findSlowEquations(profJsonFile, infoJsonFile; threshold)
+    findSlowEquations(profJsonFile, infoJsonFile; threshold = 0.03, ignoreInit = true)
 
 Read JSON profiling file and find slowest non-linear loop equatiosn that need more then `threshold` of total simulation time.
 
@@ -383,7 +383,7 @@ end
 
 
 """
-    minMaxValuesReSim(vars, modelName, moFiles; pathToOmc="" workingDir=pwd())
+    minMaxValuesReSim(vars, modelName, moFiles; options)
 
 (Re-)simulate Modelica model and find miminum and maximum value each variable has during simulation.
 

--- a/src/profiling.jl
+++ b/src/profiling.jl
@@ -80,7 +80,7 @@ function simulateWithProfiling(modelName::String,
 
     @debug "simulate"
     outputFormat = options.outputFormat === Nothing ? "csv" : options.outputFormat
-    msg = OMJulia.sendExpression(omc, "simulate($(modelName), outputFormat=\"$(outputFormat)\", simflags=\"-lv=LOG_STATS -clock=RT -cpu -w\")")
+    msg = OMJulia.sendExpression(omc, "simulate($(modelName), outputFormat=\"$(outputFormat)\", simflags=\"-lv=LOG_STATS -clock=RT -cpu -w $(options.simFlags)\")")
     write(logFile, msg["messages"]*"\n")
     msg = OMJulia.sendExpression(omc, "getErrorString()")
     write(logFile, msg*"\n")

--- a/src/types.jl
+++ b/src/types.jl
@@ -135,6 +135,8 @@ struct OMOptions
   clean::Bool
   "Additional comannd line options for `setCommandLineOptions`."
   commandLineOptions::String
+  "Additional simulation flags."
+  simFlags::String
 
   """
       OMOptions(;pathToOmc = "", workingDir = pwd(), outputFormat = "csv", clean = false, commandLineOptions = "", disableCSE = true)
@@ -146,6 +148,7 @@ struct OMOptions
                     outputFormat::Union{String,Nothing} = "csv",
                     clean::Bool = false,
                     commandLineOptions::String = "",
+                    simFlags::String = "",
                     disableCSE = true)
 
   # Try to find omc executable
@@ -161,7 +164,7 @@ struct OMOptions
     commandLineOptions *= " --preOptModules-=wrapFunctionCalls --postOptModules-=wrapFunctionCalls"
   end
 
-  new(pathToOmc, workingDir, outputFormat, clean, commandLineOptions)
+  new(pathToOmc, workingDir, outputFormat, clean, commandLineOptions, simFlags)
   end
 end
 


### PR DESCRIPTION
Adding simulation flags to `OMOptions` to set simulation flags during model simulation (profiling).